### PR TITLE
Add bools Part 2: AND and OR reducer

### DIFF
--- a/src/interpreter/bool_reducers.rs
+++ b/src/interpreter/bool_reducers.rs
@@ -13,7 +13,14 @@ pub fn reduce_and(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
 }
 
 pub fn reduce_or(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
-    unimplemented!()
+    let bool_result = unwrap_bool_token_vec(stack);
+    if let Ok(bool_vec) = bool_result {
+        Ok(Token::Operand(Type::Bool(
+            bool_vec.iter().any(|b| *b)
+        )))
+    } else {
+        Err(RuntimeError{ })
+    }
 }
 
 fn unwrap_bool_token_vec(tokens: &Vec<Token>) -> Result<Vec<bool>, RuntimeError> {
@@ -41,4 +48,44 @@ fn it_should_reduce_trues_to_true() {
     let expected = Token::Operand(Type::Bool(true));
     let actual = reduce_and(&mut stack).expect("error on valid bool stack");
     assert!(expected == actual, "failed to reduce all trues to true with AND");
+}
+
+#[test]
+fn it_should_reduce_mixed_to_false() {
+    let mut stack = vec![
+        Token::Operand(Type::Bool(true)),
+        Token::Operand(Type::Bool(true)),
+        Token::Operand(Type::Bool(false)),
+        Token::Operand(Type::Bool(true)),
+    ];
+
+    let expected = Token::Operand(Type::Bool(false));
+    let actual = reduce_and(&mut stack).expect("error on valid bool stack");
+    assert!(expected == actual, "failed to reduce all false on mixed vec with AND");
+}
+
+#[test]
+fn it_should_reduce_mixed_to_true() {
+    let mut stack = vec![
+        Token::Operand(Type::Bool(true)),
+        Token::Operand(Type::Bool(false)),
+        Token::Operand(Type::Bool(false)),
+    ];
+
+    let expected = Token::Operand(Type::Bool(true));
+    let actual = reduce_or(&mut stack).expect("error on valid bool stack");
+    assert!(expected == actual, "failed to reduce mixed vec to true with OR");
+}
+
+#[test]
+fn it_should_reduce_falses_to_false() {
+    let mut stack = vec![
+        Token::Operand(Type::Bool(false)),
+        Token::Operand(Type::Bool(false)),
+        Token::Operand(Type::Bool(false)),
+    ];
+
+    let expected = Token::Operand(Type::Bool(false));
+    let actual = reduce_or(&mut stack).expect("error on valid bool stack");
+    assert!(expected == actual, "failed to reduce all false vec to false with OR");
 }

--- a/src/interpreter/bool_reducers.rs
+++ b/src/interpreter/bool_reducers.rs
@@ -1,0 +1,44 @@
+use token::{Token, Type};
+use runtime_error::RuntimeError;
+
+pub fn reduce_and(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
+    let bool_result = unwrap_bool_token_vec(stack);
+    if let Ok(bool_vec) = bool_result {
+        Ok(Token::Operand(Type::Bool(
+            bool_vec.iter().all(|b| *b)
+        )))
+    } else {
+        Err(RuntimeError{ })
+    }
+}
+
+pub fn reduce_or(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
+    unimplemented!()
+}
+
+fn unwrap_bool_token_vec(tokens: &Vec<Token>) -> Result<Vec<bool>, RuntimeError> {
+    let result : Vec<bool> = tokens.iter().filter_map(|t| match *t {
+        Token::Operand(Type::Bool(val)) => Some(val),
+        _ => None,
+    })
+    .collect();
+    if result.len() == tokens.len() {
+        Ok(result)
+    } else {
+        Err(RuntimeError{})
+    }
+}
+
+#[test]
+fn it_should_reduce_trues_to_true() {
+    let mut stack = vec![
+        Token::Operand(Type::Bool(true)),
+        Token::Operand(Type::Bool(true)),
+        Token::Operand(Type::Bool(true)),
+        Token::Operand(Type::Bool(true)),
+    ];
+
+    let expected = Token::Operand(Type::Bool(true));
+    let actual = reduce_and(&mut stack).expect("error on valid bool stack");
+    assert!(expected == actual, "failed to reduce all trues to true with AND");
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,4 +1,5 @@
 use token::{Token, Opcode, Type};
+mod bool_reducers;
 use runtime_error::RuntimeError;
 
 
@@ -64,7 +65,9 @@ fn reduce<'a>(stack: &mut Vec<Token>) {
                 Opcode::Add => reduce_addition(&mut stack_to_resolve),
                 Opcode::Subtract => reduce_subtraction(&mut stack_to_resolve),
                 Opcode::Multiply => reduce_multiplication(&mut stack_to_resolve),
-                Opcode::Divide => reduce_division(&mut stack_to_resolve)
+                Opcode::Divide => reduce_division(&mut stack_to_resolve),
+                Opcode::And => bool_reducers::reduce_and(&mut stack_to_resolve),
+                Opcode::Or => bool_reducers::reduce_or(&mut stack_to_resolve),
             }
         },
         _ => Err(RuntimeError{})

--- a/src/token.rs
+++ b/src/token.rs
@@ -10,7 +10,7 @@ pub enum Token {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Opcode {
-    Add, Subtract, Multiply, Divide,
+    Add, Subtract, Multiply, Divide, And, Or
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -25,6 +25,8 @@ impl fmt::Display for Opcode {
             Opcode::Subtract => write!(f, "Subtract"),
             Opcode::Multiply => write!(f, "Multiply"),
             Opcode::Divide => write!(f, "Divide"),
+            Opcode::And => write!(f, "And"),
+            Opcode::Or => write!(f, "Or"),
         }
     }
 }


### PR DESCRIPTION
In prep for handling bools in this calculator repl, I need to be able to reduce a vector of bools with AND and OR. This adds, but does not really use, those reducers, with accompanying tests.