### PR TITLE
No more warnings

### DIFF
--- a/src/interpreter/comparison_reducers.rs
+++ b/src/interpreter/comparison_reducers.rs
@@ -1,5 +1,5 @@
 use std::isize;
-use token::{Token, Opcode, Type};
+use token::{Token, Type};
 use runtime_error::RuntimeError;
 use super::helpers;
 

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -1,4 +1,4 @@
-use token::{Token, Opcode, Type};
+use token::{Token, Type};
 use runtime_error::RuntimeError;
 
 pub fn unwrap_integer_tokens(tokens: &Vec<Token>) -> Result<Vec<isize>, RuntimeError> {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,5 +1,4 @@
 use token::{Token, Opcode, Type};
-use token::Type::*;
 mod bool_reducers;
 mod comparison_reducers;
 mod helpers;
@@ -142,8 +141,10 @@ fn reduce_division(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
     }
 }
 
-
-
+#[cfg(test)]
+mod tests {
+    use token::Type::*;
+    use super::*;
 #[test]
 fn it_adds_arrays() {
     let mut array = vec![
@@ -266,4 +267,5 @@ fn it_should_handle_all_bool_tree() {
     let expected = Type::Bool(true);
     let actual = eval(tokens).expect("fail to parse simple bool expression");
     assert!(expected == actual, "failed to eval simple 'and'");
+}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 #[macro_use]
 extern crate nom;
 extern crate termion;


### PR DESCRIPTION
Add module attribute to deny (treat as errors) compiler warnings,
and fix all warnings. All the warnings were either unused imports,
which can be removed, or imports used only for tests. If the
import was used only for tests, create a tests module to contain
the import.