### PR TITLE
Reverse stack in comparison reducers

### DIFF
--- a/src/interpreter/comparison_reducers.rs
+++ b/src/interpreter/comparison_reducers.rs
@@ -8,11 +8,10 @@ pub fn reduce_gt(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
     if let Ok(integers) = integers_vec {
         if integers.len() >= 2 {
             let mut result = true;
-            integers.iter().fold(isize::MAX, |a, b| {
-                // intentionally reversed operator
-                // other stack operations will cause the operands to reach this 
-                // block in reverse order.
-                result = result && (a < *b);
+            // rev because what's coming in was built up by pushing a stack,
+            // but order matters for these comparators
+            integers.iter().rev().fold(isize::MAX, |a, b| {
+                result = result && (a > *b);
                 *b
             });
             return Ok(Token::Operand(Type::Bool(
@@ -28,11 +27,10 @@ pub fn reduce_lt(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
     if let Ok(integers) = integers_vec {
         if integers.len() >= 2 {
             let mut result = true;
-            integers.iter().fold(isize::MIN, |a, b| {
-                // intentionally reversed operator
-                // other stack operations will cause the operands to reach this 
-                // block in reverse order.
-                result = result && (a > *b);
+            // rev because what's coming in was built up by pushing a stack,
+            // but order matters for these comparators
+            integers.iter().rev().fold(isize::MIN, |a, b| {
+                result = result && (a < *b);
                 *b
             });
             return Ok(Token::Operand(Type::Bool(
@@ -48,7 +46,7 @@ fn one_is_less_than_two() {
     let mut stack = vec![
         Token::Operand(Type::Integer(1)),
         Token::Operand(Type::Integer(2)),
-    ];
+    ].into_iter().rev().collect();
     let expected = Token::Operand(Type::Bool(true));
     let actual = reduce_lt(&mut stack).expect("failed to reduce stack for LT");
     assert!(expected == actual);
@@ -59,7 +57,7 @@ fn two_is_greater_than_one() {
     let mut stack = vec![
         Token::Operand(Type::Integer(2)),
         Token::Operand(Type::Integer(1)),
-    ];
+    ].into_iter().rev().collect();
     let expected = Token::Operand(Type::Bool(true));
     let actual = reduce_gt(&mut stack).expect("failed to reduce stack for LT");
     assert!(expected == actual);

--- a/src/interpreter/comparison_reducers.rs
+++ b/src/interpreter/comparison_reducers.rs
@@ -58,3 +58,5 @@ fn two_is_greater_than_one() {
     let actual = reduce_gt(&mut stack).expect("failed to reduce stack for LT");
     assert!(expected == actual);
 }
+
+// TODO think hard about how stacks get reversed in order

--- a/src/interpreter/comparison_reducers.rs
+++ b/src/interpreter/comparison_reducers.rs
@@ -9,7 +9,10 @@ pub fn reduce_gt(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
         if integers.len() >= 2 {
             let mut result = true;
             integers.iter().fold(isize::MAX, |a, b| {
-                result = result && (a > *b);
+                // intentionally reversed operator
+                // other stack operations will cause the operands to reach this 
+                // block in reverse order.
+                result = result && (a < *b);
                 *b
             });
             return Ok(Token::Operand(Type::Bool(
@@ -26,7 +29,10 @@ pub fn reduce_lt(stack: &mut Vec<Token>) -> Result<Token, RuntimeError> {
         if integers.len() >= 2 {
             let mut result = true;
             integers.iter().fold(isize::MIN, |a, b| {
-                result = result && (a < *b);
+                // intentionally reversed operator
+                // other stack operations will cause the operands to reach this 
+                // block in reverse order.
+                result = result && (a > *b);
                 *b
             });
             return Ok(Token::Operand(Type::Bool(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -267,3 +267,28 @@ fn it_should_handle_all_bool_tree() {
     let actual = eval(tokens).expect("fail to parse simple bool expression");
     assert!(expected == actual, "failed to eval simple 'and'");
 }
+
+#[test]
+fn it_should_handle_comparisons() {
+    let tokens = vec![
+        Token::LeftParen,
+        Token::Operator(Opcode::And),
+            Token::LeftParen,
+            Token::Operator(Opcode::Gt),
+            Token::Operand(Type::Integer(5)),
+            Token::Operand(Type::Integer(4)),
+            Token::RightParen,
+            Token::LeftParen,
+            Token::Operator(Opcode::Lt),
+            Token::Operand(Type::Integer(0)),
+            Token::Operand(Type::Integer(4)),
+            Token::RightParen,
+        Token::RightParen
+    ];
+
+    // (and (> 5 4) (< 0 4)) => true
+
+    let expected = Type::Bool(true);
+    let actual = eval(tokens).expect("fail to parse simple bool expression");
+    assert!(expected == actual, "failed to eval complex 'and'");
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -271,6 +271,30 @@ mod tests {
     }
 
     #[test]
+    fn it_can_handle_nested_bools() {
+        let tokens = vec![
+            Token::LeftParen,
+            Token::Operator(Opcode::And),
+                Token::LeftParen,
+                Token::Operator(Opcode::And),
+                Token::Operand(Bool(true)),
+                Token::Operand(Bool(true)),
+                Token::RightParen,
+                Token::LeftParen,
+                Token::Operator(Opcode::And),
+                Token::Operand(Bool(true)),
+                Token::Operand(Bool(true)),
+                Token::RightParen,
+            Token::RightParen
+        ];
+
+
+        let expected = Type::Bool(true);
+        let actual = eval(tokens).expect("fail to parse nested bool expression");
+        assert!(expected == actual, "failed to eval nested 'and' found {:?}", actual);
+    }
+
+    #[test]
     fn it_should_handle_comparisons() {
         let tokens = vec![
             Token::LeftParen,
@@ -289,6 +313,26 @@ mod tests {
         ];
 
         // (and (> 5 4) (< 0 4)) => true
+        let expected = Type::Bool(true);
+        let actual = eval(tokens).expect("fail to parse simple bool expression");
+        assert!(expected == actual, "failed to eval complex 'and'");
+    }
+
+        #[test]
+    fn it_should_handle_one_comparison() {
+        let tokens = vec![
+            Token::LeftParen,
+            Token::Operator(Opcode::And),
+                Token::LeftParen,
+                Token::Operator(Opcode::Gt),
+                Token::Operand(Type::Integer(5)),
+                Token::Operand(Type::Integer(4)),
+                Token::RightParen,
+                Token::Operand(Type::Bool(true)),
+            Token::RightParen
+        ];
+
+        // (and (> 5 4) true) => true
         let expected = Type::Bool(true);
         let actual = eval(tokens).expect("fail to parse simple bool expression");
         assert!(expected == actual, "failed to eval complex 'and'");

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -250,7 +250,7 @@ mod tests {
         assert!(expected == actual, "failed to eval complex 'and'");
     }
 
-        #[test]
+    #[test]
     fn it_should_handle_one_comparison() {
         let tokens = vec![
             Token::LeftParen,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ fn main() {
     repl::repl();
 }
 
-// TODO write some end to end tests that exercise the parser and interpreter together
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
+    fn it_can_reduce_comparisons() {
         let input = b"(and (> 5 4) (< 0 4))";
         let tokens = parser::parse(&input[..]).expect("failed to tokenize boolean expression");
         let result = interpreter::eval(tokens).expect("failed to eval boolean expression");

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,9 @@ mod tests {
     #[test]
     fn it_subtracts_correctly() {
         let input = b"(- 1 2 2 2)";
-        let mut tokens = parser::parse(&input);
-        let actual = interpreter::eval(&mut tokens)
+        let tokens = parser::parse(&input[..])
+            .expect("failed to parse subtraction string");
+        let actual = interpreter::eval(tokens)
             .expect("failed to eval simple subtraction");
         let expected = Type::Integer(-5);
         assert!(expected == actual, "expect {} but got {}", expected, actual);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,3 +12,5 @@ mod tokenization_error;
 fn main() {
     repl::repl();
 }
+
+// TODO write some end to end tests that exercise the parser and interpreter together

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,14 @@ mod tests {
     }
 
     #[test]
+    fn it_can_reduce_comparisons_with_other_ops() {
+        let input = b"(or (> 5 4 (- 2 1)) (< 7 4))";
+        let tokens = parser::parse(&input[..]).expect("failed to tokenize boolean expression");
+        let result = interpreter::eval(tokens).expect("failed to eval boolean expression");
+        assert!(result == token::Type::Bool(true));
+    }
+
+    #[test]
     fn it_subtracts_correctly() {
         let input = b"(- 1 2 2 2)";
         let tokens = parser::parse(&input[..])

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 #[macro_use]
 extern crate nom;
 extern crate termion;
@@ -14,3 +16,15 @@ fn main() {
 }
 
 // TODO write some end to end tests that exercise the parser and interpreter together
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let input = b"(and (> 5 4) (< 0 4))";
+        let tokens = parser::parse(&input[..]).expect("failed to tokenize boolean expression");
+        let result = interpreter::eval(tokens).expect("failed to eval boolean expression");
+        assert!(result == token::Type::Bool(true));
+    }
+}


### PR DESCRIPTION
The argument to comparison reducers is built up by pushing onto a
stack. Pushing is the easiest way to build up this vector, but we
need to have the comparisons operate on the array in normal order,
not in stack order. For now, we're just reversing in place.