### PR TITLE
fail tokenization early if entire string cannot be consumed

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
 
 use nom;
+use nom::IResult;
 use token::{Token,Opcode,Type};
 use tokenization_error::TokenizationError;
 use std::str;
@@ -103,10 +104,15 @@ named!(tokens<&[u8], Vec<Token>>,
 );
 
 pub fn parse(bytes: &[u8]) -> Result<Vec<Token>, TokenizationError> {
-    let parse_result = tokens(bytes).to_result();
+    let parse_result = tokens(bytes);
     match parse_result {
-        Ok(token_vec) => Ok(token_vec),
-        Err(_) => Err(TokenizationError {})
+        IResult::Done(rest, result) => if rest.is_empty() {
+            Ok(result)
+        } else {
+            Err(TokenizationError{})
+        },
+        IResult::Error(_) => Err(TokenizationError {}),
+        IResult::Incomplete(_) => Err(TokenizationError{}),
     }
 }
 


### PR DESCRIPTION
It seems that, previously, tokenization would appear to succeed as long as some of the string could be consumed. For example, calling parse on `"( + NONSENSE NONSENSE"` would return `Ok([Token::LeftParen, Token::Operator(Opcode::Add)])`, but I expected it to return `Err(TokenizationError{})`. 

This change makes tokenization intentionally fail if we can't consume the entire input string.